### PR TITLE
Fix for issue with install in root directory on Windows server

### DIFF
--- a/framework/classes/Url.inc
+++ b/framework/classes/Url.inc
@@ -391,6 +391,11 @@ class Url {
 
     // print $directory;
 
+    // Get the root directory right on Windows
+    if ($directory === '\\') {
+      $directory = '';
+    }
+
     $port = $_SERVER['SERVER_PORT'];
     $scheme = self::https() ? 'https' : 'http';
 


### PR DESCRIPTION
This fixes an issue with Velox when installed in the web root on a Windows server. dirname($_SERVER['SCRIPT_NAME']) returns "\" which causes URL's to be generated as "http://example.com/\/directory".
